### PR TITLE
Use Mojolicious to ensure we have access to Mojolicious::VERSION

### DIFF
--- a/lib/Log/Any/Adapter/MojoLog.pm
+++ b/lib/Log/Any/Adapter/MojoLog.pm
@@ -9,6 +9,7 @@ $VERSION = eval $VERSION;
 use Log::Any::Adapter::Util qw(make_method);
 use base qw(Log::Any::Adapter::Base);
 
+use Mojolicious;
 use Mojo::Log;
 
 sub init {


### PR DESCRIPTION
The adapter reads the version number from Mojolicious, but it could be used in a module that has not loaded Mojolicious. So this variable might not be defined.

Sadly, the version number is not defined anywhere in the Mojolicious codebase, so in order to have access to it, Mojolicious needs to be loaded.

This patch loads Mojolicious in the adapter to ensure that's the case.
